### PR TITLE
Don't add invalid link relations to HAL output

### DIFF
--- a/lib/oat/adapters/hal.rb
+++ b/lib/oat/adapters/hal.rb
@@ -3,7 +3,7 @@ module Oat
   module Adapters
     class HAL < Oat::Adapter
       def link(rel, opts = {})
-        data[:_links][rel] = opts
+        data[:_links][rel] = opts if opts[:href]
       end
 
       def properties(&block)

--- a/spec/adapters/hal_spec.rb
+++ b/spec/adapters/hal_spec.rb
@@ -17,6 +17,8 @@ describe Oat::Adapters::HAL do
         h[:controller_name].should == 'some_controller'
         # links
         h[:_links][:self][:href].should == "http://foo.bar.com/#{user.id}"
+        # HAL Spec says href is REQUIRED
+        h[:_links].should_not include(:empty)
         # embedded manager
         h[:_embedded][:manager].tap do |m|
           m[:id].should == manager.id

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -12,6 +12,7 @@ module Fixtures
         schema do
           type 'user'
           link :self, href: url_for(item.id)
+          link :empty, href: nil
 
           property :id, item.id
           map_properties :name, :age


### PR DESCRIPTION
HAL spec says that the href property of a link relation is
required. Certain parsers, thus, will break if a nil href is
included in the spec. This PR simply checks to make sure these
don't show up in the JSON output if the link you pass in happens
to be nil.
