### PR TITLE
Serializer from block or class update

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ class CustomAdapter < Oat::Adapter
   end
 
   def entity(name, obj, serializer_class = nil, &block)
-    data[:nested_documents] = serializer_from_block_or_class(obj, serializer_class, &block)
+    data[:nested_documents] = serializer_from_block_or_class(obj, serializer_class, &block).to_hash
   end
 
   ... etc
@@ -502,7 +502,7 @@ class SocialAdapter < Oat::Adapter
 
   def friends(friend_list, serializer_class = nil, &block)
     data[:friends] = friend_list.map do |obj|
-      serializer_from_block_or_class(obj, serializer_class, &block)
+      serializer_from_block_or_class(obj, serializer_class, &block).to_hash
     end
   end
 end

--- a/lib/oat/adapter.rb
+++ b/lib/oat/adapter.rb
@@ -29,9 +29,9 @@ module Oat
         serializer_class.adapter self.class
         s = serializer_class.new(obj, serializer.context, serializer.adapter_class, serializer.top)
         serializer.top.instance_exec(obj, s, &block)
-        s.to_hash
+        s
       else
-        serializer_class.new(obj, serializer.context, serializer.adapter_class).to_hash
+        serializer_class.new(obj, serializer.context, serializer.adapter_class)
       end
     end
   end

--- a/lib/oat/adapters/hal.rb
+++ b/lib/oat/adapters/hal.rb
@@ -15,12 +15,14 @@ module Oat
       end
 
       def entity(name, obj, serializer_class = nil, &block)
-        data[:_embedded][name] = serializer_from_block_or_class(obj, serializer_class, &block)
+        entity_serializer = serializer_from_block_or_class(obj, serializer_class, &block)
+        data[:_embedded][name] = entity_serializer ? entity_serializer.to_hash : nil
       end
 
       def entities(name, collection, serializer_class = nil, &block)
         data[:_embedded][name] = collection.map do |obj|
-          serializer_from_block_or_class(obj, serializer_class, &block)
+          entity_serializer = serializer_from_block_or_class(obj, serializer_class, &block)
+          entity_serializer ? entity_serializer.to_hash : nil
         end
       end
 

--- a/lib/oat/adapters/json_api.rb
+++ b/lib/oat/adapters/json_api.rb
@@ -61,7 +61,7 @@ module Oat
 
       def entity_without_root(obj, serializer_class = nil, &block)
         ent = serializer_from_block_or_class(obj, serializer_class, &block)
-        ent.values.first.first if ent
+        ent.to_hash.values.first.first if ent
       end
 
     end

--- a/lib/oat/adapters/siren.rb
+++ b/lib/oat/adapters/siren.rb
@@ -28,7 +28,7 @@ module Oat
 
       def entity(name, obj, serializer_class = nil, &block)
         ent = serializer_from_block_or_class(obj, serializer_class, &block)
-        data[:entities] << ent if ent
+        data[:entities] << ent.to_hash if ent
       end
 
       def entities(name, collection, serializer_class = nil, &block)


### PR DESCRIPTION
It's useful for serializer_from_block_or_class to return the serializer object and that's what the name implies it is retuning.

This then allows the json_api to access the root_name element on the child entities thus no longer requiring the root element to appear first in the hash. Relying on the order of keys in the hash should typically be avoided. (Especially on ruby 1.8)
