### PR TITLE
Return safe serializers in nested adapters using NullSerializer

### DIFF
--- a/lib/oat.rb
+++ b/lib/oat.rb
@@ -2,5 +2,6 @@ require "oat/version"
 
 module Oat
   require 'oat/serializer'
+  require 'oat/null_serializer'
   require 'oat/adapter'
 end

--- a/lib/oat/adapter.rb
+++ b/lib/oat/adapter.rb
@@ -22,16 +22,16 @@ module Oat
     end
 
     def serializer_from_block_or_class(obj, serializer_class = nil, context_options = {}, &block)
-      return nil if obj.nil?
+      return NullSerializer.new if obj.nil?
 
       if block_given?
         serializer_class = Class.new(serializer.class)
         serializer_class.adapter self.class
         s = serializer_class.new(obj, serializer.context.merge(context_options), serializer.adapter_class, serializer.top)
         serializer.top.instance_exec(obj, s, &block)
-        s.to_hash
+        s
       else
-        serializer_class.new(obj, serializer.context.merge(context_options), serializer.adapter_class, serializer.top).to_hash
+        serializer_class.new(obj, serializer.context.merge(context_options), serializer.adapter_class, serializer.top)
       end
     end
   end

--- a/lib/oat/adapters/hal.rb
+++ b/lib/oat/adapters/hal.rb
@@ -15,12 +15,12 @@ module Oat
       end
 
       def entity(name, obj, serializer_class = nil, context_options = {}, &block)
-        data[:_embedded][name] = serializer_from_block_or_class(obj, serializer_class, context_options, &block)
+        data[:_embedded][name] = serializer_from_block_or_class(obj, serializer_class, context_options, &block).to_hash
       end
 
       def entities(name, collection, serializer_class = nil, context_options = {}, &block)
         data[:_embedded][name] = collection.map do |obj|
-          serializer_from_block_or_class(obj, serializer_class, context_options, &block)
+          serializer_from_block_or_class(obj, serializer_class, context_options, &block).to_hash
         end
       end
 

--- a/lib/oat/adapters/json_api.rb
+++ b/lib/oat/adapters/json_api.rb
@@ -34,7 +34,7 @@ module Oat
 
       def entity(name, obj, serializer_class = nil, context_options = {}, &block)
         @entities[name.to_s.pluralize.to_sym] ||= []
-        ent = serializer_from_block_or_class(obj, serializer_class, context_options, &block)
+        ent = serializer_from_block_or_class(obj, serializer_class, context_options, &block).to_hash
         if ent
           link name, :href => ent[:id]
           @entities[name.to_s.pluralize.to_sym] << ent
@@ -47,7 +47,7 @@ module Oat
 
         collection.each do |obj|
           @entities[link_name] ||= []
-          ent = serializer_from_block_or_class(obj, serializer_class, context_options, &block)
+          ent = serializer_from_block_or_class(obj, serializer_class, context_options, &block).to_hash
           if ent
             data[:links][link_name] << ent[:id]
             @entities[link_name] << ent

--- a/lib/oat/adapters/siren.rb
+++ b/lib/oat/adapters/siren.rb
@@ -27,7 +27,7 @@ module Oat
       end
 
       def entity(name, obj, serializer_class = nil, context_options = {}, &block)
-        ent = serializer_from_block_or_class(obj, serializer_class, context_options, &block)
+        ent = serializer_from_block_or_class(obj, serializer_class, context_options, &block).to_hash
         data[:entities] << ent if ent
       end
 

--- a/lib/oat/null_serializer.rb
+++ b/lib/oat/null_serializer.rb
@@ -1,0 +1,12 @@
+require 'support/class_attribute'
+module Oat
+  class NullSerializer
+    def method_missing(*args)
+      self
+    end
+
+    def to_hash
+      nil
+    end
+  end
+end


### PR DESCRIPTION
As mentioned in #19 and #16.

This implements the [`NullObject` pattern](http://devblog.avdi.org/2011/05/30/null-objects-and-falsiness/), in which we return a chainable `NullSerializer` object for all messages except `#to_hash`, which returns `nil`.
