### PR TITLE
Allow for serializing json api resource collections into root key

### DIFF
--- a/lib/oat/adapter.rb
+++ b/lib/oat/adapter.rb
@@ -28,7 +28,7 @@ module Oat
         serializer_class = Class.new(serializer.class)
         serializer_class.adapter self.class
         s = serializer_class.new(obj, serializer.context.merge(context_options), serializer.adapter_class, serializer.top)
-        serializer.top.instance_exec(obj, s, &block)
+        serializer.instance_exec(obj, s, &block)
         s.to_hash
       else
         serializer_class.new(obj, serializer.context.merge(context_options), serializer.adapter_class, serializer.top).to_hash

--- a/lib/oat/adapters/hal.rb
+++ b/lib/oat/adapters/hal.rb
@@ -23,6 +23,7 @@ module Oat
           serializer_from_block_or_class(obj, serializer_class, context_options, &block)
         end
       end
+      alias_method :collection, :entities
 
     end
   end

--- a/lib/oat/adapters/siren.rb
+++ b/lib/oat/adapters/siren.rb
@@ -36,6 +36,7 @@ module Oat
           entity name, obj, serializer_class, context_options, &block
         end
       end
+      alias_method :collection, :entities
 
       def action(name, &block)
         action = Action.new(name)

--- a/spec/adapters/json_api_spec.rb
+++ b/spec/adapters/json_api_spec.rb
@@ -97,5 +97,75 @@ describe Oat::Adapters::JsonAPI do
         hash.fetch(:linked).fetch(:managers).should be_empty
       end
     end
+
+    context 'with an entity collection' do
+      let(:serializer_collection_class) do
+        USER_SERIALIZER = serializer_class unless defined?(USER_SERIALIZER)
+        Class.new(Oat::Serializer) do
+          schema do
+            type 'users'
+            collection :users, item, USER_SERIALIZER
+          end
+        end
+      end
+
+      let(:collection_serializer){
+        serializer_collection_class.new(
+          [user,friend],
+          {:name => "some_controller"},
+          Oat::Adapters::JsonAPI
+        )
+      }
+      let(:collection_hash) { collection_serializer.to_hash }
+
+      context 'top level' do
+        subject(:users){ collection_hash.fetch(:users) }
+        its(:size) { should eq(2) }
+
+        it 'contains the correct first user properties' do
+          expect(users[0]).to include(
+            :id => user.id,
+            :name => user.name,
+            :age => user.age,
+            :controller_name => 'some_controller',
+            :message_from_above => nil
+          )
+        end
+
+        it 'contains the correct second user properties' do
+          expect(users[1]).to include(
+            :id => friend.id,
+            :name => friend.name,
+            :age => friend.age,
+            :controller_name => 'some_controller',
+            :message_from_above => nil
+          )
+        end
+
+        it 'contains the correct user links' do
+          expect(users.first.fetch(:links)).to include(
+            :self => "http://foo.bar.com/#{user.id}",
+            # these links are added by embedding entities
+            :manager => manager.id,
+            :friends => [friend.id]
+          )
+        end
+
+        context 'sub entity' do
+          subject(:linked_managers){ collection_hash.fetch(:linked).fetch(:managers) }
+          its(:size) { should eq(1) }
+
+          it "contains the correct properties and links" do
+            expect(linked_managers.first).to include(
+              :id => manager.id,
+              :name => manager.name,
+              :age => manager.age,
+              :links => { :self => "http://foo.bar.com/#{manager.id}" }
+            )
+          end
+        end
+      end
+
+    end
   end
 end


### PR DESCRIPTION
How do you feel about this schema for json api resource collections?

``` ruby
schema do
  type 'users'
  entities :users, item, USER_SERIALIZER, {:type => :resource_collection}
 end
```
