### PR TITLE
Don't allow rake 10.2 on ruby 1.8.7

### DIFF
--- a/gemfiles/Gemfile.as-1.4.4
+++ b/gemfiles/Gemfile.as-1.4.4
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in oat.gemspec
 gem 'activesupport', '1.4.4'
+gem 'rake', '< 10.2'
 gemspec :path => "../"

--- a/gemfiles/Gemfile.as-2.3.x
+++ b/gemfiles/Gemfile.as-2.3.x
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in oat.gemspec
 gem 'activesupport', '~>2.3.18'
+gem 'rake', '< 10.2'
 gemspec :path => "../"

--- a/gemfiles/Gemfile.as-3.0.x
+++ b/gemfiles/Gemfile.as-3.0.x
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in oat.gemspec
 gem 'activesupport', '~>3.0.20'
 gem 'i18n'
+gem 'rake', '< 10.2'
 gemspec :path => "../"

--- a/gemfiles/Gemfile.as-3.1.x
+++ b/gemfiles/Gemfile.as-3.1.x
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in oat.gemspec
 gem 'activesupport', '~>3.1.12'
 gem 'i18n'
+gem 'rake', '< 10.2'
 gemspec :path => "../"

--- a/gemfiles/Gemfile.as-3.2.x
+++ b/gemfiles/Gemfile.as-3.2.x
@@ -2,4 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in oat.gemspec
 gem 'activesupport', '~>3.2.16'
+gem 'rake', '< 10.2'
 gemspec :path => "../"


### PR DESCRIPTION
Rake 10.2 was just release and it is ruby >= 1.9 only. This change forces rake versions less than 10.2 for the tests that will run on ruby 1.8.7.
