### PR TITLE
Don't block NoMethodErrors from raising

### DIFF
--- a/lib/oat/serializer.rb
+++ b/lib/oat/serializer.rb
@@ -35,7 +35,7 @@ module Oat
       if adapter.respond_to?(name)
         adapter.send(name, *args, &block)
       else
-        self.class.warn "[#{adapter.class}] does not implement ##{name}. Called with #{args}"
+        super
       end
     end
 

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -10,7 +10,7 @@ module Fixtures
         klass = self
 
         schema do
-          type 'user'
+          type 'user' if respond_to?(:type)
           link :self, :href => url_for(item.id)
           link :empty, :href => nil
 
@@ -33,13 +33,15 @@ module Fixtures
             end
           end
 
-          action :close_account do |action|
-            action.href "http://foo.bar.com/#{item.id}/close_account"
-            action.class 'danger'
-            action.class 'irreversible'
-            action.method 'DELETE'
-            action.field :current_password do |field|
-              field.type :password
+          if respond_to?(:action)
+            action :close_account do |action|
+              action.href "http://foo.bar.com/#{item.id}/close_account"
+              action.class 'danger'
+              action.class 'irreversible'
+              action.method 'DELETE'
+              action.field :current_password do |field|
+                field.type :password
+              end
             end
           end
         end


### PR DESCRIPTION
This is bad practice, and I'm not quite sure why we do it.

In one case, it has a particularly annoying side-effect of not
being able to turn off the warnings, despite a NoMethodError being
expected.

``` ruby
class AssignmentSerializer < Oat::Serializer
  include Rails.application.routes.url_helpers
  adapter Oat::Adapters::HAL

  schema do
    link assignable_path(item.assignable) if assignable_path(item.assignable)
  end

  def assignable_path(assignable)
    routable_klass = item.assignable_type.constantize
    # don't throw warnings to serializer if the route doesn't exist
    @assignable_path ||= begin 
      polymorphic_path([:api, assignable.becomes(routable_klass)]) if routable_klass
    rescue NoMethodError
      nil
    end
  end
end
```

Normal behavior if the route doesn't exist is to throw a `NoMethodError`, but since `Oat::Serializer` doesn't call `super` in `method_missing`, it never gets thrown. Ideally, the user is in charge of handling `NoMethodError`. The warning might be nice, but it's too dangerous to override `method_missing` without calling `super`.
