### PR TITLE
Add type attribute for siren actions

### DIFF
--- a/lib/oat/adapters/siren.rb
+++ b/lib/oat/adapters/siren.rb
@@ -66,7 +66,7 @@ module Oat
           data[:fields] << field.data
         end
 
-        %w(href method title).each do |attribute|
+        %w(href method title type).each do |attribute|
           define_method(attribute) do |value|
             data[attribute.to_sym] = value
           end

--- a/spec/adapters/siren_spec.rb
+++ b/spec/adapters/siren_spec.rb
@@ -64,7 +64,8 @@ describe Oat::Adapters::Siren do
         :name => :close_account,
         :href => "http://foo.bar.com/#{user.id}/close_account",
         :class => ['danger', 'irreversible'],
-        :method => 'DELETE'
+        :method => 'DELETE',
+        :type => 'application/json'
       )
       expect(actions.first.fetch(:fields)).to include(
         :name => :current_password,

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -41,6 +41,7 @@ module Fixtures
               action.class 'danger'
               action.class 'irreversible'
               action.method 'DELETE'
+              action.type   'application/json'
               action.field :current_password do |field|
                 field.type :password
               end


### PR DESCRIPTION
This is a very small PR which allows adding the `type` attribute to `actions` in the Siren adapter.
As seen in the [Siren docs](https://github.com/kevinswiber/siren#type)
