### PR TITLE
Update to rspec3

### DIFF
--- a/oat.gemspec
+++ b/oat.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec", ">= 3.0"
+  spec.add_development_dependency "rspec-its"
 end

--- a/spec/adapters/json_api_spec.rb
+++ b/spec/adapters/json_api_spec.rb
@@ -104,7 +104,7 @@ describe Oat::Adapters::JsonAPI do
         its(:size) { should eq(2) }
 
         it 'has the correct entities' do
-          linked_friends.map{ |friend| friend.fetch(:id) }.should include(2, 4)
+          expect(linked_friends.map{ |friend| friend.fetch(:id) }).to include(2, 4)
         end
       end
     end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -49,7 +49,7 @@ describe Oat::Serializer do
   let(:user1) { user_class.new('Ismael', 35, 1, []) }
 
   it 'should have a version number' do
-    Oat::VERSION.should_not be_nil
+    expect(Oat::VERSION).to_not be_nil
   end
 
   describe "#context" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'rspec/its'
 require 'oat'
 require 'fixtures'


### PR DESCRIPTION
## WHAT?

The gemspec doesn't specify the rspec version for oat. When I checked out out oat and ran `bundle install`, bundler installed rspec 3. Unfortunately the tests raise errors, and the tests don't run.

This PR upgrades oat to use rspec3
## HOW?

To make this work, I've added the new rspec-its gem, so that examples that use `its` still work. I've also converted the `should` expectation syntax to the `expect` expectation syntax in a couple of places (to remove warnings)
