### PR TITLE
Feature/individual entity

### DIFF
--- a/lib/oat/adapters/json_api.rb
+++ b/lib/oat/adapters/json_api.rb
@@ -11,12 +11,15 @@ module Oat
   module Adapters
 
     class JsonAPI < Oat::Adapter
-
       def initialize(*args)
         super
         @entities = {}
         @link_templates = {}
         @meta = {}
+      end
+
+      def individual
+        @individual = true
       end
 
       def type(*types)
@@ -110,6 +113,8 @@ module Oat
           h = {}
           if @treat_as_resource_collection
             h[root_name] = data[:resource_collection]
+          elsif @individual
+            h[root_name] = data
           else
             h[root_name] = [data]
           end
@@ -138,7 +143,9 @@ module Oat
       end
 
       def entity_name(name)
-        name = name.pluralize
+        unless @individual
+          name = name.pluralize
+        end
         name.to_sym
       end
 

--- a/lib/oat/adapters/json_api.rb
+++ b/lib/oat/adapters/json_api.rb
@@ -20,7 +20,7 @@ module Oat
       end
 
       def type(*types)
-        @root_name = types.first.to_s.pluralize.to_sym
+        @root_name = entity_name(types.first.to_s)
       end
 
       def link(rel, opts = {})
@@ -69,15 +69,16 @@ module Oat
         ent = serializer_from_block_or_class(obj, serializer_class, context_options, &block)
         if ent
           ent_hash = ent.to_hash
-          entity_hash[name.to_s.pluralize.to_sym] ||= []
+          ent_name = entity_name(name.to_s)
+          entity_hash[ent_name] ||= []
           data[:links][name] = ent_hash[:id]
-          entity_hash[name.to_s.pluralize.to_sym] << ent_hash
+          entity_hash[ent_name] << ent_hash
         end
       end
 
       def entities(name, collection, serializer_class = nil, context_options = {}, &block)
         return if collection.nil? || collection.empty?
-        link_name = name.to_s.pluralize.to_sym
+        link_name = entity_name(name.to_s)
         data[:links][link_name] = []
 
         collection.each do |obj|
@@ -134,6 +135,11 @@ module Oat
       def entity_without_root(obj, serializer_class = nil, &block)
         ent = serializer_from_block_or_class(obj, serializer_class, &block)
         ent.to_hash.values.first.first if ent
+      end
+
+      def entity_name(name)
+        name = name.pluralize
+        name.to_sym
       end
 
     end

--- a/lib/oat/adapters/json_api.rb
+++ b/lib/oat/adapters/json_api.rb
@@ -23,7 +23,7 @@ module Oat
       end
 
       def type(*types)
-        @root_name = entity_name(types.first.to_s)
+        @root_name = entity_name(types.first)
       end
 
       def link(rel, opts = {})
@@ -72,7 +72,7 @@ module Oat
         ent = serializer_from_block_or_class(obj, serializer_class, context_options, &block)
         if ent
           ent_hash = ent.to_hash
-          ent_name = entity_name(name.to_s)
+          ent_name = entity_name(name)
           entity_hash[ent_name] ||= []
           data[:links][name] = ent_hash[:id]
           entity_hash[ent_name] << ent_hash
@@ -81,7 +81,7 @@ module Oat
 
       def entities(name, collection, serializer_class = nil, context_options = {}, &block)
         return if collection.nil? || collection.empty?
-        link_name = entity_name(name.to_s)
+        link_name = entity_name(name)
         data[:links][link_name] = []
 
         collection.each do |obj|
@@ -143,10 +143,7 @@ module Oat
       end
 
       def entity_name(name)
-        unless @individual
-          name = name.pluralize
-        end
-        name.to_sym
+        name.to_s.pluralize.to_sym
       end
 
     end

--- a/lib/oat/serializer.rb
+++ b/lib/oat/serializer.rb
@@ -39,6 +39,12 @@ module Oat
       end
     end
 
+    def individual
+      if adapter.respond_to?(:individual) && adapter.method(:individual).arity == 0
+        adapter.individual
+      end
+    end
+
     def type(*args)
       if adapter.respond_to?(:type) && adapter.method(:type).arity != 0
         adapter.type(*args)

--- a/spec/adapters/json_api_spec.rb
+++ b/spec/adapters/json_api_spec.rb
@@ -5,8 +5,10 @@ describe Oat::Adapters::JsonAPI do
 
   include Fixtures
 
+  let(:individual_serializer) { individual_serializer_class.new(user, {:name => 'some_controller'}, Oat::Adapters::JsonAPI) }
   let(:serializer) { serializer_class.new(user, {:name => 'some_controller'}, Oat::Adapters::JsonAPI) }
   let(:hash) { serializer.to_hash }
+  let(:individual_hash) { individual_serializer.to_hash }
 
   describe '#to_hash' do
     context 'top level' do
@@ -31,6 +33,24 @@ describe Oat::Adapters::JsonAPI do
           # these links are added by embedding entities
           :manager => manager.id,
           :friends => [friend.id]
+        )
+      end
+    end
+
+    context 'individual top level' do
+      subject(:individual_user){ individual_hash.fetch(:user) }
+
+      it 'is not an array' do
+        expect(individual_user).not_to be_kind_of(Array)
+      end
+
+      it 'contains the correct user properties' do
+        expect(individual_user).to include(
+          :id => user.id,
+          :name => user.name,
+          :age => user.age,
+          :controller_name => 'some_controller',
+          :message_from_above => nil
         )
       end
     end

--- a/spec/adapters/json_api_spec.rb
+++ b/spec/adapters/json_api_spec.rb
@@ -38,7 +38,7 @@ describe Oat::Adapters::JsonAPI do
     end
 
     context 'individual top level' do
-      subject(:individual_user){ individual_hash.fetch(:user) }
+      subject(:individual_user){ individual_hash.fetch(:users) }
 
       it 'is not an array' do
         expect(individual_user).not_to be_kind_of(Array)

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -5,6 +5,25 @@ module Fixtures
     base.let(:friend) { user_class.new('Joe', 33, 2, []) }
     base.let(:manager) { user_class.new('Jane', 29, 3, []) }
     base.let(:user) { user_class.new('Ismael', 35, 1, [friend], manager) }
+
+    base.let(:individual_serializer_class) do
+      Class.new(Oat::Serializer) do
+        klass = self
+        schema do
+          individual # set this entity as an individual resource
+          type 'user' if respond_to?(:type)
+
+          property :id, item.id
+          map_properties :name, :age
+
+          properties do |attrs|
+            attrs.controller_name context[:name]
+            attrs.message_from_above context[:message]
+          end
+        end
+      end
+    end
+
     base.let(:serializer_class) do
       Class.new(Oat::Serializer) do
         klass = self


### PR DESCRIPTION
I'm sure there is a nicer way to do this, but hopefully this gets oat moving in the right direction. 
Adds support for individual resources at the top-level in JsonAPI without breaking existing behaviors.

The spec says:
> An individual resource SHOULD be represented as a single "resource object" (described below) or a string value containing its ID (also described below).

This change works by setting a flag in the serializer ('individual') that indicates you want a singular resource. 

I originally modified the inflection rules as well (so if you specify 'individual' we don't try to pluralize the names), but then I decided against it and went back to pluralizing everywhere for consistency. You can see that moment of self-doubt in the commit history.

Note: it might be useful to _also_ include a flag to turn off pluralization for those few cases where a plural name makes no sense (like in this case, where I was writing /api/status)

Usage:
```
class Status < Oat::Serializer
  adapter Oat::Adapters::JsonAPI
  schema do
    individual
    type 'status'
    map_properties *%i(at status)
  end
end
```

Output:
```
{
    "statuses": {
        "at": "2014-09-21T08:24:12.807-07:00",
        "status": "unknown"
    }
}
```