### PR TITLE
Stop entities/entity from duplicating entries in linked hash.

### DIFF
--- a/lib/oat/adapters/json_api.rb
+++ b/lib/oat/adapters/json_api.rb
@@ -74,9 +74,13 @@ module Oat
         if ent
           ent_hash = ent.to_hash
           _name = entity_name(name)
-          entity_hash[_name.to_s.pluralize.to_sym] ||= []
+          link_name = _name.to_s.pluralize.to_sym
           data[:links][_name] = ent_hash[:id]
-          entity_hash[_name.to_s.pluralize.to_sym] << ent_hash
+
+          entity_hash[link_name] ||= []
+          unless entity_hash[link_name].include? ent_hash
+            entity_hash[link_name] << ent_hash
+          end
         end
       end
 
@@ -92,7 +96,9 @@ module Oat
           if ent
             ent_hash = ent.to_hash
             data[:links][link_name] << ent_hash[:id]
-            entity_hash[link_name] << ent_hash
+            unless entity_hash[link_name].include? ent_hash
+              entity_hash[link_name] << ent_hash
+            end
           end
         end
       end

--- a/lib/oat/adapters/siren.rb
+++ b/lib/oat/adapters/siren.rb
@@ -40,7 +40,11 @@ module Oat
         if ent
           # use the name as the sub-entities rel to the parent resource.
           ent.rel(name)
-          data[:entities] << ent.to_hash
+          ent_hash = ent.to_hash
+
+          unless data[:entities].include? ent_hash
+            data[:entities] << ent_hash
+          end
         end
       end
 

--- a/spec/adapters/json_api_spec.rb
+++ b/spec/adapters/json_api_spec.rb
@@ -84,7 +84,10 @@ describe Oat::Adapters::JsonAPI do
 
       context 'using #entity' do
         subject(:linked_managers){ hash.fetch(:linked).fetch(:managers) }
-        its(:size) { should eq(1) }
+
+        it "does not duplicate an entity that is associated with 2 objects" do
+          expect(linked_managers.size).to eq(1)
+        end
 
         it "contains the correct properties and links" do
           expect(linked_managers.first).to include(
@@ -313,7 +316,10 @@ describe Oat::Adapters::JsonAPI do
 
         context 'sub entity' do
           subject(:linked_managers){ collection_hash.fetch(:linked).fetch(:managers) }
-          its(:size) { should eq(1) }
+
+          it "does not duplicate an entity that is associated with multiple objects" do
+            expect(linked_managers.size).to eq(1)
+          end
 
           it "contains the correct properties and links" do
             expect(linked_managers.first).to include(

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -3,7 +3,7 @@ module Fixtures
   def self.included(base)
     base.let(:user_class) { Struct.new(:name, :age, :id, :friends, :manager) }
     base.let(:friend) { user_class.new('Joe', 33, 2, []) }
-    base.let(:manager) { user_class.new('Jane', 29, 3, []) }
+    base.let(:manager) { user_class.new('Jane', 29, 3, [friend]) }
     base.let(:user) { user_class.new('Ismael', 35, 1, [friend], manager) }
     base.let(:serializer_class) do
       Class.new(Oat::Serializer) do
@@ -33,6 +33,8 @@ module Fixtures
               attrs.name manager.name
               attrs.age manager.age
             end
+
+            entities [:friends, 'http://example.org/rels/person'], item.friends, klass, :message => "Merged into parent's context"
           end
 
           if adapter.respond_to?(:action)


### PR DESCRIPTION
As specified at http://jsonapi.org/format:

> If a primary document is linked to another primary or linked document, it should not be duplicated within the "linked" object.

The current json api adapter will duplicate documents in the "linked" object if multiple other documents link to it. 

For example, the current implementation would do this:

```javascript
{
  :purchases => [
    {
      :id => 1,
      :links =>
      {
        :bids => [2],
        :game => 3
      }
    }
  ],
  :linked => {
    :bids => [
      {:id => 2},
      {:id => 2}
    ],
    :games => [
      {
        :id => 3,
        :links => {
          :bids => [2]
        }
      }
    ]
  }
}
```

Instead of this:

```javascript
{
  :purchases => [
    {
      :id => 1,
      :links =>
      {
        :bids => [2],
        :game => 3
      }
    }
  ],
  :linked => {
    :bids => [
      {:id => 2}
    ],
    :games => [
      {
        :id => 3,
        :links => {
          :bids => [2]
        }
      }
    ]
  }
}
```

Notice the incorrect double entry under [:linked][:bids].

This pull request fixes that.

I started to add some tests, but didn't have enough time to make the necessary changes to the fixtures to accommodate the tests. The fix is simple enough, though.