### PR TITLE
Allow action fields to have a class

### DIFF
--- a/lib/oat/adapters/siren.rb
+++ b/lib/oat/adapters/siren.rb
@@ -91,7 +91,11 @@ module Oat
           attr_reader :data
 
           def initialize(name)
-            @data = { :name => name }
+            @data = { :name => name, :class => []}
+          end
+
+          def class(value)
+            data[:class] << value
           end
 
           %w(type value title).each do |attribute|

--- a/spec/adapters/siren_spec.rb
+++ b/spec/adapters/siren_spec.rb
@@ -74,6 +74,7 @@ describe Oat::Adapters::Siren do
       )
 
       expect(actions.first.fetch(:fields)).to include(
+        :class => ['string'],
         :name => :current_password,
         :type => :password,
         :title => 'enter password:'

--- a/spec/fixtures.rb
+++ b/spec/fixtures.rb
@@ -46,6 +46,7 @@ module Fixtures
               action.method 'DELETE'
               action.type   'application/json'
               action.field :current_password do |field|
+                field.class 'string'
                 field.type :password
                 field.title 'enter password:'
               end


### PR DESCRIPTION
Hi.  Thanks for making Oat!

I added the ability to add classes to Siren action fields, as described in [version 0.6.1 of the Siren spec](https://github.com/kevinswiber/siren#class-4)

Please consider merging this into ismasan/oat .
