### PR TITLE
Add support for multiple schema blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,17 @@ class SocialSerializer < Oat::Serializer
 end
 ```
 
+You can specify multiple schema blocks, including across class hierarchies. This allows us to append schema attributes or override previously defined attributes:
+
+```ruby
+class ExtendedUserSerializer < UserSerializer
+  schema do
+    name item.full_name # name property will now by the user's full name
+    property :dob, item.dob # additional date of birth attribute
+  end
+end
+```
+
 ## URLs
 
 Hypermedia is all about the URLs linking your resources together. Oat adapters can have methods to declare links in your entity schema but it's up to your code/framework how to create those links.

--- a/lib/oat/adapter.rb
+++ b/lib/oat/adapter.rb
@@ -26,6 +26,7 @@ module Oat
 
       if block_given?
         serializer_class = Class.new(serializer.class)
+        serializer_class.schemas = []
         serializer_class.adapter self.class
         s = serializer_class.new(obj, serializer.context.merge(context_options), serializer.adapter_class, serializer.top)
         serializer.instance_exec(obj, s, &block)

--- a/lib/oat/serializer.rb
+++ b/lib/oat/serializer.rb
@@ -2,11 +2,12 @@ require 'support/class_attribute'
 module Oat
   class Serializer
 
-    class_attribute :_adapter, :logger
+    class_attribute :_adapter, :logger, :schemas
+
+    self.schemas = []
 
     def self.schema(&block)
-      @schema = block if block_given?
-      @schema || Proc.new{}
+      self.schemas += [block] if block_given?
     end
 
     def self.adapter(adapter_class = nil)
@@ -51,7 +52,10 @@ module Oat
 
     def to_hash
       @to_hash ||= (
-        instance_eval(&self.class.schema)
+        self.class.schemas.each do |schema|
+          instance_eval(&schema)
+        end
+
         adapter.to_hash
       )
     end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -78,6 +78,39 @@ describe Oat::Serializer do
         :self => "http://foo.bar.com/#{user1.id}"
       )
     end
-  end
 
+    context "when multiple schema blocks are specified across a class hierarchy" do
+      let(:child_serializer) {
+        Class.new(@sc) do
+          schema do
+            attribute :id_plus_x, "#{item.id}_x"
+
+            attributes do |attrs|
+              attrs.inherited "true"
+            end
+          end
+        end
+      }
+
+      it "produces the result of both schema blocks in order" do
+        serializer = child_serializer.new(user1, name: "child_controller")
+
+        expect(serializer.to_hash.fetch(:attributes)).to include(
+          special: 'Hello',
+          id: user1.id,
+          id_plus_x: "#{user1.id}_x",
+          inherited: "true",
+        )
+      end
+
+      it "does not affect the parent serializer" do
+        serializer = @sc.new(user1, :name => 'some_controller')
+
+        attributes = serializer.to_hash.fetch(:attributes)
+
+        expect(attributes).to_not have_key(:id_plus_x)
+        expect(attributes).to_not have_key(:inherited)
+      end
+    end
+  end
 end

--- a/spec/serializer_spec.rb
+++ b/spec/serializer_spec.rb
@@ -93,13 +93,13 @@ describe Oat::Serializer do
       }
 
       it "produces the result of both schema blocks in order" do
-        serializer = child_serializer.new(user1, name: "child_controller")
+        serializer = child_serializer.new(user1, :name => "child_controller")
 
         expect(serializer.to_hash.fetch(:attributes)).to include(
-          special: 'Hello',
-          id: user1.id,
-          id_plus_x: "#{user1.id}_x",
-          inherited: "true",
+          :special => 'Hello',
+          :id => user1.id,
+          :id_plus_x => "#{user1.id}_x",
+          :inherited => "true"
         )
       end
 


### PR DESCRIPTION
Add support for multiple schema blocks, either within the same class definition, or inheritable across a class hierarchy. For example a child serializer, which allows us to append/override previously defined schema attributes:

```ruby
class SlimUserSerializer < Oat::Serializer
  adapter Oat::Adapters::HAL

  schema do
    property :name, item.short_name
    property :email, item.email
  end
end

class FullUserSerializer < SlimUserSerializer
  schema do
    property :name, item.full_name
    property :dob, item.dob
  end
end
```

`SlimUserSerializer` will produce output like:

```json
{
  "name": "Homer",
  "email": "homer.j.simpson@example.com"
}
```

`FullUserSerializer` will produce output like:

```json
{
  "name": "Homer Jay Simpson",
  "email": "homer.j.simpson@example.com",
  "dob": "1955-05-12"
}
```

Depending on the adaptor, existing data may be added to or overwritten. For example with the HAL adaptor an entity with a given name will always override any previous entity already defined with the same name. With the Siren adaptor, it will be added to the list of existing entities (assuming it’s not a complete duplicate of another sub-entity).

Note: this does not include the refactoring we talked about offline. I think this is useful on its own.