### PR TITLE
Improve serialization performance by avoiding instance_eval and method_missing

### DIFF
--- a/lib/oat/adapter.rb
+++ b/lib/oat/adapter.rb
@@ -27,6 +27,7 @@ module Oat
       if block_given?
         serializer_class = Class.new(serializer.class)
         serializer_class.schemas = []
+        serializer_class.schema_methods = []
         serializer_class.adapter self.class
         s = serializer_class.new(obj, serializer.context.merge(context_options), serializer.adapter_class, serializer.top)
         serializer.instance_exec(obj, s, &block)

--- a/lib/oat/serializer.rb
+++ b/lib/oat/serializer.rb
@@ -44,7 +44,15 @@ module Oat
 
     def method_missing(name, *args, &block)
       if adapter.respond_to?(name)
-        adapter.send(name, *args, &block)
+        self.class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          private
+
+          def #{name}(*args, &block)
+            adapter.#{name}(*args, &block)
+          end
+        RUBY
+
+        send(name, *args, &block)
       else
         super
       end

--- a/lib/oat/serializer.rb
+++ b/lib/oat/serializer.rb
@@ -1,13 +1,23 @@
 require 'support/class_attribute'
+
 module Oat
   class Serializer
 
-    class_attribute :_adapter, :logger, :schemas
+    class_attribute :_adapter, :logger, :schemas, :schema_methods
 
     self.schemas = []
+    self.schema_methods = []
 
     def self.schema(&block)
-      self.schemas += [block] if block_given?
+      if block_given?
+        schema_method_name = :"schema_block_#{self.schema_methods.count}"
+
+        self.schemas += [block]
+        self.schema_methods += [schema_method_name]
+
+        define_method(schema_method_name, &block)
+        private(schema_method_name)
+      end
     end
 
     def self.adapter(adapter_class = nil)
@@ -52,8 +62,8 @@ module Oat
 
     def to_hash
       @to_hash ||= (
-        self.class.schemas.each do |schema|
-          instance_eval(&schema)
+        self.class.schema_methods.each do |schema_method_name|
+          send(schema_method_name)
         end
 
         adapter.to_hash


### PR DESCRIPTION
Hello there!

I'm currently working on improving the performance of @Talkdesk systems using Oat for serialization, and after reporting an issue on JRuby relating to Oat performance in some setups (https://github.com/jruby/jruby/issues/4596), @headius suggested that Oat performance was being limited by its usage of `instance_eval` and `method_missing`.

After other optimization work, time spent for serialization on our system is now quite a big slice of total request serving time, and thus I decided to finally look into improving Oat's performance by avoiding the two pitfalls mentioned above.

This PR includes two optimizations to Oat. **Together, they improve Oat performance on the benchmark below by 41% on MRI and 252% on JRuby when compared to the master branch.** See the individual commit messages for more specifics on each optimization.

Benchmark used (using `benchmark-ips`):

```ruby
require 'benchmark/ips'
require 'oat'
require 'oat/adapters/hal'

class Foo
  attr_reader :foo, :bar, :baz

  def initialize(**values)
    values.each do |(key, value)|
      respond_to?(key) ? instance_variable_set(:"@#{key}", value) : raise
    end
  end
end

class FooSerializer < Oat::Serializer
  adapter Oat::Adapters::HAL

  schema do
    property :foo, item.foo
    property :bar, item.bar
    property :baz, item.baz
  end
end

puts "Running with #{RUBY_DESCRIPTION}"

FOO = Foo.new(foo: 1, bar: 2, baz: 'baz')

Benchmark.ips do |benchmark|
  benchmark.time = 30
  benchmark.warmup = 30
  benchmark.report('FooSerializer') { FooSerializer.new(FOO).to_hash }
  benchmark.compare!
end
```

I was unsure if it was useful to also commit the benchmark itself to Oat's repository, so if you think it's useful I can add it to this PR.

Thanks for Oat (it's really useful), and have an awesome day!