### PR TITLE
Allow for more sophisticated pluralization

### DIFF
--- a/lib/oat/adapters/json_api.rb
+++ b/lib/oat/adapters/json_api.rb
@@ -150,6 +150,8 @@ module Oat
       PLURAL = /s$/
 
       def pluralize(str)
+        return str.pluralize if str.respond_to?(:pluralize)
+        
         if str =~ PLURAL
           str
         else


### PR DESCRIPTION
While removing the dependency on ActiveSupport is good, it sometimes results in suboptimal results.

Therefore, allow the hosting application to provide the String with a pluralize-method. This could come from ActiveSupport or a custom method, tailored towards the need of the application. 

If this method is not available, continue with the naïve implementation that works most of the time.